### PR TITLE
Always try to use SELinux macros

### DIFF
--- a/src/nvidia-container-selinux/nvidia-container.te
+++ b/src/nvidia-container-selinux/nvidia-container.te
@@ -32,6 +32,4 @@ read_files_pattern(nvidia_container_t, container_runtime_tmpfs_t, container_runt
 # --- running nvidia-smi
 allow nvidia_container_t xserver_exec_t:file { entrypoint execute getattr open read execute_no_trans };
 # --- alloc mem, ... /dev/nvidia*
-allow nvidia_container_t xserver_misc_device_t:chr_file { getattr ioctl open read write map };
-
-####dev_rw_xserver_misc(nvidia_container_t)
+dev_rw_xserver_misc(nvidia_container_t)


### PR DESCRIPTION
One should always try to use an SELinux macro if possible. Access patterns to specific files can change and hence the rule has to be updated. Update to rules are often updated in the macro, so the changes are used automatically. 