### PR TITLE
Add rule to allow nvidia-smi in docker to access the persistenced socket

### DIFF
--- a/src/nvidia-container-selinux/nvidia-container.te
+++ b/src/nvidia-container-selinux/nvidia-container.te
@@ -6,6 +6,7 @@ gen_require(`
         type container_runtime_tmpfs_t;
         type xserver_exec_t;
 	type xserver_misc_device_t;
+	type xserver_t;
 
 	attribute sandbox_net_domain;
 	attribute sandbox_caps_domain;
@@ -31,5 +32,6 @@ read_files_pattern(nvidia_container_t, container_runtime_tmpfs_t, container_runt
 
 # --- running nvidia-smi
 allow nvidia_container_t xserver_exec_t:file { entrypoint execute getattr open read execute_no_trans };
+allow nvidia_container_t xserver_t:unix_stream_socket { connectto getattr read write };
 # --- alloc mem, ... /dev/nvidia*
 dev_rw_xserver_misc(nvidia_container_t)


### PR DESCRIPTION
When nvidia-smi is run within a docker container the Persistence Mode is reported as "Off" even when Persistence Mode is on.
This is because nvidia-smi tries to communicate with nvidia-persistenced through the socket at /var/run/nvidia-persistenced/socket.

This pull request adds a new "allow" line to allow nvidia_container_t to access that socket.