### PR TITLE
Update nvidia-container.te

### DIFF
--- a/src/nvidia-container-selinux/nvidia-container.te
+++ b/src/nvidia-container-selinux/nvidia-container.te
@@ -33,3 +33,7 @@ read_files_pattern(nvidia_container_t, container_runtime_tmpfs_t, container_runt
 allow nvidia_container_t xserver_exec_t:file { entrypoint execute getattr open read execute_no_trans };
 # --- alloc mem, ... /dev/nvidia*
 dev_rw_xserver_misc(nvidia_container_t)
+
+
+# --- send audit messages
+logging_send_audit_msgs(nvidia_container_t)


### PR DESCRIPTION
Running `sudo` inside a `nvidia_container_t` context fails with errors since the policy was missing the rules for sending audit messages. 
The other part why it failed was that the capability `CAP_AUDIT_WRITE` is not enabled by default. We need to run  the invocation with `--cap-add=AUDIT_WRITE`. 

With those two changes we have a clean `sudo mkdir DIR` inside of the container. 

```
 podman run  --cap-add=AUDIT_WRITE --security-opt label=type:nvidia_container_t --rm -it selinux sudo mktemp                                                                                                                                                              
/tmp/tmp.1XpA6b2LCV
```

Omitting the `--cap-add=AUDIT_WRITE` will result in the execution of  `sudo command` but will print an error. 

```
$ podman run   --security-opt label=type:nvidia_container_t --rm -it selinux sudo mktemp 
sudo: unable to send audit message: Operation not permitted
/tmp/tmp.mECUaQVBQr
```

If something fails with the new policy we need to make sure that the host is correclty labelled. 

Restorecon all files that the prestart hook will need
```
# nvidia-container-cli -k list | restorecon -v -f -
```
Restorecon  all accessed devices
```
# restorecon -Rv /dev
```