### PR TITLE
Fix SELinux nvidia-docker permission denied error

### DIFF
--- a/src/nvidia-container-selinux/nvidia-container.te
+++ b/src/nvidia-container-selinux/nvidia-container.te
@@ -3,9 +3,12 @@
 policy_module(nvidia-container, 0.1)
 
 gen_require(`
-        type container_runtime_tmpfs_t;
-        type xserver_exec_t;
+	type container_runtime_tmpfs_t;
+	type container_runtime_exec_t;
+	type xserver_exec_t;
 	type xserver_misc_device_t;
+	type xserver_var_run_t;
+	type xserver_t;
 
 	attribute sandbox_net_domain;
 	attribute sandbox_caps_domain;
@@ -29,9 +32,12 @@ getattr_dirs_pattern(nvidia_container_t, container_runtime_tmpfs_t, container_ru
 list_dirs_pattern(nvidia_container_t, container_runtime_tmpfs_t, container_runtime_tmpfs_t)
 read_files_pattern(nvidia_container_t, container_runtime_tmpfs_t, container_runtime_tmpfs_t)
 
+# --- running nvidia-docker
+allow xserver_t container_runtime_exec_t:file entrypoint;
+
 # --- running nvidia-smi
 allow nvidia_container_t xserver_exec_t:file { entrypoint execute getattr open read execute_no_trans };
-# --- alloc mem, ... /dev/nvidia*
+allow nvidia_container_t xserver_t:unix_stream_socket connectto;
 dev_rw_xserver_misc(nvidia_container_t)
 
 


### PR DESCRIPTION
This patch adds a policy to allow xserver_t and container_runtime_exec_t file entrypoint permission to allow nvidia-docker bash script to exec docker.

The policy we will allow is the one suggested from the audit logs:

-----------------------------------------------------
module testpolicy 1.0;

require {
    type container_runtime_exec_t;
    type xserver_t;
    class file entrypoint;
}

allow xserver_t container_runtime_exec_t:file entrypoint;
--------------------------------------------------
This was tested by building an RPM, installing it on a DGX-1, and running the command:

sudo nvidia-docker run --gpus=all --rm nvcr.io/nvidia/cuda:11.0-base nvidia-smi

When run before this fix, we were getting the error

$ sudo nvidia-docker run --gpus=all --rm nvcr.io/nvidia/cuda:11.0-base nvidia-smi
/bin/nvidia-docker: line 34: /bin/docker: Permission denied
/bin/nvidia-docker: line 34: /bin/docker: Success